### PR TITLE
dts: Fix reference to optee_memory

### DIFF
--- a/linux-v5.4/stm32mp157c-osd32mp1-brk.dts
+++ b/linux-v5.4/stm32mp157c-osd32mp1-brk.dts
@@ -1014,7 +1014,7 @@
 	};
 };
 
-&optee{
+&optee_memory{
 	status = "okay";
 };
 

--- a/u-boot-v2020.01/stm32mp157c-osd32mp1-brk.dts
+++ b/u-boot-v2020.01/stm32mp157c-osd32mp1-brk.dts
@@ -1014,7 +1014,7 @@
 	};
 };
 
-&optee{
+&optee_memory{
 	status = "okay";
 };
 


### PR DESCRIPTION
Update the use of the undefined label `optee` to `optee_memory`, which is the
label for the optee instance in this system.